### PR TITLE
Adding twistlock and blackduck information

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -19,6 +19,10 @@ Bandit
 ------
 JSON report format
 
+Blackduck Hub
+-------------
+Import the security.csv file.
+
 Bundler-Audit
 -------------
 Import the text output generated with bundle-audit check

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -112,6 +112,14 @@ Trufflehog
 ----------
 JSON Output of Trufflehog.
 
+Twistlock
+---------
+JSON output of the ``twistcli`` tool. Example:
+
+.. code-block:: bash
+
+   ./twistcli images scan <REGISTRY/REPO:TAG> --address https://<SECURE_URL_OF_TWISTLOCK_CONSOLE> --user <USER> --details --output-file=<PATH_TO_SAVE_JSON_FILE>
+
 Visual Code Grepper (VCG)
 -------------------------
 VCG output can be imported in CSV or Xml formats.


### PR DESCRIPTION
`$ python -m rstvalidator integrations.rst` does not show any error and passes on http://rst.ninjs.org.

Complements https://github.com/DefectDojo/django-DefectDojo/pull/1113

@aaronweaver 