### PR TITLE
Add trailing slash in Jira webhook

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -580,7 +580,7 @@ DefectDojo's JIRA integration is bidirectional. You may push findings to JIRA an
 Preparing Jira, Enabling the Webhook
  1. Visit https://<**YOUR JIRA URL**>/plugins/servlet/webhooks
  2. Click 'Create a Webhook'
- 3. For the field labeled 'URL' enter: https://<**YOUR DOJO DOMAIN**>/webhook
+ 3. For the field labeled 'URL' enter: https://<**YOUR DOJO DOMAIN**>/webhook/
  4. Under 'Comments' enable 'Created'. Under Issue enable 'Updated'.
 
 Configurations in Dojo


### PR DESCRIPTION
Trailing slash is required as per https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/settings/settings.dist.py#L237

This fixes https://github.com/DefectDojo/django-DefectDojo/issues/691