### PR TITLE
Add trivy scanner to the list of integrations

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -233,6 +233,10 @@ Testssl Scan
 ----------------
 Import CSV output of testssl scan report.
 
+Trivy
+-----
+JSON report of `trivy scanner <https://github.com/aquasecurity/trivy>`_.
+
 Trufflehog
 ----------
 JSON Output of Trufflehog.


### PR DESCRIPTION
Update documentation for the issue django-DefectDojo#1562