### PR TITLE
Add Xanitizer to the list of scanner parsers

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -270,6 +270,10 @@ Wpscan Scanner
 ---------------
 Import JSON report.
 
+Xanitizer
+---------
+Import XML findings list report, preferably with parameter 'generateDetailsInFindingsListReport=true'.
+
 Zed Attack Proxy
 ----------------
 ZAP XML report format.

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -233,6 +233,10 @@ Testssl Scan
 ----------------
 Import CSV output of testssl scan report.
 
+Trivy
+-----
+JSON report of `trivy scanner <https://github.com/aquasecurity/trivy>`_.
+
 Trufflehog
 ----------
 JSON Output of Trufflehog.

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -1,3 +1,6 @@
+Integrations
+============
+
 DefectDojo has the ability to import reports from other security tools.
 
 Acunetix Scanner


### PR DESCRIPTION
Add Xanitizer to the list of scanner parser for [pull request](https://github.com/DefectDojo/django-DefectDojo/pull/1679) on OWASP DefectDojo project.