### PR TITLE
Update Jira documentation

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -622,7 +622,7 @@ Configurations in Dojo
 Adding JIRA to Dojo
  1. Click 'JIRA' from the left hand menu.
  2. Select 'Add Configuration' from the drop-down.
- 3. For the password, you need to generate an `API token for Jira <https://id.atlassian.com/manage/api-tokens>`_ to use as password
+ 3. If you use Jira Cloud, you will need to generate an `API token for Jira <https://id.atlassian.com/manage/api-tokens>`_ to use as the password
  4. To obtain the 'open status key' and 'closed status key' visit https://<**YOUR JIRA URL**>/rest/api/latest/issue/<**ANY VALID ISSUE KEY**>/transitions?expand=transitions.fields
  5. The 'id' for 'Todo' should be filled in as the 'open status key'
  6. The 'id' for 'Done' should be filled in as the 'closed status key'

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -622,9 +622,10 @@ Configurations in Dojo
 Adding JIRA to Dojo
  1. Click 'JIRA' from the left hand menu.
  2. Select 'Add Configuration' from the drop-down.
- 3. To obtain the 'open status key' and 'closed status key' visit https://<**YOUR JIRA URL**>/rest/api/latest/issue/<**ANY VALID ISSUE KEY**>/transitions?expand=transitions.fields
- 4. The 'id' for 'Todo' should be filled in as the 'open status key'
- 5. The 'id' for 'Done' should be filled in as the 'closed status key'
+ 3. For the password, you need to generate an `API token for Jira <https://id.atlassian.com/manage/api-tokens>`_ to use as password
+ 4. To obtain the 'open status key' and 'closed status key' visit https://<**YOUR JIRA URL**>/rest/api/latest/issue/<**ANY VALID ISSUE KEY**>/transitions?expand=transitions.fields
+ 5. The 'id' for 'Todo' should be filled in as the 'open status key'
+ 6. The 'id' for 'Done' should be filled in as the 'closed status key'
 
  To obtain 'epic name id':
  If you have admin access to JIRA:

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -622,9 +622,10 @@ Configurations in Dojo
 Adding JIRA to Dojo
  1. Click 'JIRA' from the left hand menu.
  2. Select 'Add Configuration' from the drop-down.
- 3. To obtain the 'open status key' and 'closed status key' visit https://<**YOUR JIRA URL**>/rest/api/latest/issue/<**ANY VALID ISSUE KEY**>/transitions?expand=transitions.fields
- 4. The 'id' for 'Todo' should be filled in as the 'open status key'
- 5. The 'id' for 'Done' should be filled in as the 'closed status key'
+ 3. For the password, you need to generate an `API token for Jira https://id.atlassian.com/manage/api-tokens`_ 
+ 4. To obtain the 'open status key' and 'closed status key' visit https://<**YOUR JIRA URL**>/rest/api/latest/issue/<**ANY VALID ISSUE KEY**>/transitions?expand=transitions.fields
+ 5. The 'id' for 'Todo' should be filled in as the 'open status key'
+ 6. The 'id' for 'Done' should be filled in as the 'closed status key'
 
  To obtain 'epic name id':
  If you have admin access to JIRA:


### PR DESCRIPTION
Jira has [deprecated and removed](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-basic-auth-and-cookie-based-auth/) password authentication to the REST API. Jira Cloud [requires to create an API token](https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/) to connect to the REST API using Basic Auth. 

Adding this information to the documentation might save lot of time for DefectDojo users.