### PR TITLE
Remove heroku information + reposition docker-compose as recommended

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -5,11 +5,10 @@ Docker Compose Install (recommended)
 ************************************
 * Go to https://github.com/DefectDojo/django-DefectDojo
 * Select the appropriate branch you're working on
-* Under "Installation Options" click "Docker"
-* Follow the instructions
+* Instructions in the `DOCKER.md` file at the root of the repository.
 
-Setup.bash Install (default)
-****************************
+Setup.bash Install 
+******************
 .. warning::
    This installation method will be EOL on 2020-12-31
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,20 +1,12 @@
 Getting Started
 ===============
 
-Live Demo
-*********
-
-If you'd like to check out a demo of DefectDojo before installing it, you can check out on our `Heroku demo site`_.
-
-.. _Heroku demo site: https://defectdojo.herokuapp.com/
-
-You can log in as an administrator like so:
-
-* admin / defectdojo@demo#appsec
-
-You can also log in as a product owner or non-staff user:
-
-* product_manager / defectdojo@demo#product
+Docker Compose Install (recommended)
+************************************
+* Go to https://github.com/DefectDojo/django-DefectDojo
+* Select the appropriate branch you're working on
+* Under "Installation Options" click "Docker"
+* Follow the instructions
 
 Setup.bash Install (default)
 ****************************
@@ -24,11 +16,4 @@ Setup.bash Install (default)
 * Go to https://github.com/DefectDojo/django-DefectDojo
 * Select the appropriate branch you're working on
 * Under "Installation Options" click "Setup.bash"
-* Follow the instructions
-
-Docker Compose Install
-**********************
-* Go to https://github.com/DefectDojo/django-DefectDojo
-* Select the appropriate branch you're working on
-* Under "Installation Options" click "Docker"
 * Follow the instructions


### PR DESCRIPTION
Removed the no longer current heroku info.
Repositioned on top docker-compose as the recommended way to try and go.
Moved down setup.bash and removed its "default" tag.