### PR TITLE
1.7.0: add upgrade instructions rebuild watson for #2616

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -41,6 +41,26 @@ Upgrade Celery to the latest version:
 
     ``pip install --upgrade celery``
 
+Upgrading to DefectDojo Version 1.7.0 
+-------------------------------------
+
+**What's New:**
+
+ * Updated search, you can now search for CVE-XXXX-YYYY
+ * Updated search index, fields added to index: 'id', 'title', 'cve', 'url', 'severity', 'description', 'mitigation', 'impact', 'steps_to_reproduce', 'severity_justification', 'references', 'sourcefilepath', 'sourcefile', 'hash_code', 'file_path', 'component_name', 'component_version', 'unique_id_from_tool'
+
+This requires a (one-time) rebuild of the Django-Watson search index. Execute the django command from the defect dojo installation directory:
+
+`./manage.py buildwatson dojo.Finding`
+
+If you're using docker, you can open a shell to the running uwsgi container:
+
+`docker-compose exec uwsgi bash`
+
+You will land in the `/app` directory and can now execute the same command to rebuild the watson index:
+
+`./manage.py buildwatson dojo.Finding`
+
 Upgrading to DefectDojo Version 1.5.0
 -------------------------------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -53,13 +53,9 @@ This requires a (one-time) rebuild of the Django-Watson search index. Execute th
 
 `./manage.py buildwatson dojo.Finding`
 
-If you're using docker, you can open a shell to the running uwsgi container:
+If you're using docker:
 
-`docker-compose exec uwsgi bash`
-
-You will land in the `/app` directory and can now execute the same command to rebuild the watson index:
-
-`./manage.py buildwatson dojo.Finding`
+`docker-compose exec uwsgi ./manage.py buildwatson dojo.Finding`
 
 Upgrading to DefectDojo Version 1.5.0
 -------------------------------------


### PR DESCRIPTION
In https://github.com/DefectDojo/django-DefectDojo/pull/2616 we add new fields to the `Finding` index, so this needs to be rebuild on upgrade.