### PR TITLE
remove demo link as no demo available

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -332,7 +332,8 @@ Automatically Flag Duplicate Findings
     and have the same CWE or title, Dojo marks the less recent finding as a duplicate. When deduplication is enabled, a
     list of deduplicated findings is added to the engagement view.
     The following image illustrates the option deduplication on engagement and deduplication on product level:
-    .. image:: /_static/deduplication.png
+
+    .. image:: _static/deduplication.png
         :alt: Deduplication on product and engagement level
 
 Similar Findings Visualization:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,6 @@ DefectDojo is based on a model that allows the ultimate flexibility in your test
 
 The code is open source, and `available on github`_.
 
-A demo installation can be `found over at PythonAnywhere`_.
-
 .. _available on github: https://github.com/rackerlabs/django-DefectDojo
 .. _found over at PythonAnywhere: https://defectdojo.pythonanywhere.com
 


### PR DESCRIPTION
The link leads to a page at PythonAnywhere that looks like this:
<img width="593" alt="Screenshot 2020-07-07 at 13 28 35" src="https://user-images.githubusercontent.com/15032115/86781763-2c3ae880-c056-11ea-8780-86063278cf55.png">

We should remove the link and reinstate when demo available.
