### PR TITLE
Exposing prometheus metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/_build/
 .DS_Store
 *~
 .vscode/
+venv


### PR DESCRIPTION
In part `running in production`, hint about monitoring has been added. Maybe later would be nice to have it as separate chapter. 