### PR TITLE
Logging as json

### DIFF
--- a/docs/running-in-production.rst
+++ b/docs/running-in-production.rst
@@ -6,9 +6,9 @@ Improving your docker-compose performance
 
 Uwsgi and celery logs
 ^^^^^^^^^^^^^^^^^^^^^
-You may want to login your celery output and uwsgi as json to ease log processing as you ship logs to your central logging platform.
+You may want to log messages produced by your celery beat and worker as well as uwsgi to json, to ease log processing as you ship logs to your central logging platform.
 
-Setting the ``DD_LOGGING_FORMAT`` environment variable to ``json_console`` will have celery (beat and worker) as well as uwsgi log in JSON format.
+Setting the ``DD_LOGGING_FORMAT`` environment variable to ``json_console`` for these containers will have them log in JSON format.
 
 Database
 ^^^^^^^^

--- a/docs/running-in-production.rst
+++ b/docs/running-in-production.rst
@@ -8,7 +8,7 @@ Uwsgi and celery logs
 ^^^^^^^^^^^^^^^^^^^^^
 You may want to log messages produced by your celery beat and worker as well as uwsgi to json, to ease log processing as you ship logs to your central logging platform.
 
-Setting the ``DD_LOGGING_FORMAT`` environment variable to ``json_console`` for these containers will have them log in JSON format.
+Setting the ``DD_LOGGING_HANDLER`` environment variable to ``json_console`` for these containers will have them log in JSON format.
 
 Database
 ^^^^^^^^

--- a/docs/running-in-production.rst
+++ b/docs/running-in-production.rst
@@ -4,6 +4,12 @@ Running in Production
 Improving your docker-compose performance
 -----------------------------------------
 
+Uwsgi and celery logs
+^^^^^^^^^^^^^^^^^^^^^
+You may want to login your celery output and uwsgi as json to ease log processing as you ship logs to your central logging platform.
+
+Setting the ``DD_LOGGING_FORMAT`` environment variable to ``json`` will have celery (beat and worker) as well as uwsgi log in JSON format.
+
 Database
 ^^^^^^^^
 Run your database elsewhere. Tweak your docker-compose configuration to that effect.

--- a/docs/running-in-production.rst
+++ b/docs/running-in-production.rst
@@ -8,7 +8,7 @@ Uwsgi and celery logs
 ^^^^^^^^^^^^^^^^^^^^^
 You may want to login your celery output and uwsgi as json to ease log processing as you ship logs to your central logging platform.
 
-Setting the ``DD_LOGGING_FORMAT`` environment variable to ``json`` will have celery (beat and worker) as well as uwsgi log in JSON format.
+Setting the ``DD_LOGGING_FORMAT`` environment variable to ``json_console`` will have celery (beat and worker) as well as uwsgi log in JSON format.
 
 Database
 ^^^^^^^^

--- a/docs/settings-docs.rst
+++ b/docs/settings-docs.rst
@@ -111,3 +111,4 @@ DefectDojo settings.py variables
 * ``DD_SLA_NOTIFY_PRE_BREACH``: Number of days to notify before breaching the SLA.
 * ``DD_SLA_NOTIFY_POST_BREACH``: Number of days to keep notifying after the SLA has been breached.
 * ``DD_EMAIL_URL, default``:
+* ``DD_LOGGING_FORMAT``: If set to `json`, uwsgi and celery will log in json format. If not set, everything is as usual.

--- a/docs/settings-docs.rst
+++ b/docs/settings-docs.rst
@@ -111,4 +111,4 @@ DefectDojo settings.py variables
 * ``DD_SLA_NOTIFY_PRE_BREACH``: Number of days to notify before breaching the SLA.
 * ``DD_SLA_NOTIFY_POST_BREACH``: Number of days to keep notifying after the SLA has been breached.
 * ``DD_EMAIL_URL, default``:
-* ``DD_LOGGING_FORMAT``: If set to ``json``, uwsgi and celery will log in json format. If not set, everything is as usual.
+* ``DD_LOGGING_FORMAT``: If set to ``json_console``, uwsgi and celery will log in json format. If not set, everything is as usual.

--- a/docs/settings-docs.rst
+++ b/docs/settings-docs.rst
@@ -111,4 +111,4 @@ DefectDojo settings.py variables
 * ``DD_SLA_NOTIFY_PRE_BREACH``: Number of days to notify before breaching the SLA.
 * ``DD_SLA_NOTIFY_POST_BREACH``: Number of days to keep notifying after the SLA has been breached.
 * ``DD_EMAIL_URL, default``:
-* ``DD_LOGGING_FORMAT``: If set to `json`, uwsgi and celery will log in json format. If not set, everything is as usual.
+* ``DD_LOGGING_FORMAT``: If set to ``json``, uwsgi and celery will log in json format. If not set, everything is as usual.

--- a/docs/settings-docs.rst
+++ b/docs/settings-docs.rst
@@ -111,4 +111,4 @@ DefectDojo settings.py variables
 * ``DD_SLA_NOTIFY_PRE_BREACH``: Number of days to notify before breaching the SLA.
 * ``DD_SLA_NOTIFY_POST_BREACH``: Number of days to keep notifying after the SLA has been breached.
 * ``DD_EMAIL_URL, default``:
-* ``DD_LOGGING_FORMAT``: If set to ``json_console``, uwsgi and celery will log in json format. If not set, everything is as usual.
+* ``DD_LOGGING_HANDLER``: If set to ``json_console``, uwsgi and celery will log in json format. If not set, everything is as usual.


### PR DESCRIPTION
Companion for PR https://github.com/DefectDojo/django-DefectDojo/pull/3083

Doc to use `DD_LOGGING_FORMAT = json` to have logs formatted as json.